### PR TITLE
Enhance member administration workflows

### DIFF
--- a/src/components/UserAdmin.tsx
+++ b/src/components/UserAdmin.tsx
@@ -4,10 +4,12 @@ import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import { UserPlus, Search, Mail, Phone, Shield, Crown, User, UsersRound } from "lucide-react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
+import type { Database } from "@/integrations/supabase/types";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/components/ui/use-toast";
 
@@ -25,16 +27,53 @@ type UserProfile = {
   city: string | null;
   birthday: string | null;
   photo_url: string | null;
-  status: string;
+  status: string | null;
   created_at: string;
   user_roles: { role: string }[];
 };
+
+type ProfileFormState = {
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone: string;
+  mobile: string;
+  member_number: string;
+  street: string;
+  postal_code: string;
+  city: string;
+  birthday: string;
+  status: string;
+};
+
+type DialogMode = "create" | "edit";
+
+type AppRole = Database["public"]["Enums"]["app_role"];
+type NormalizedRole = "player" | "captain" | "vorstand" | "admin";
 
 export const UserAdmin = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [roleFilter, setRoleFilter] = useState("all");
   const [users, setUsers] = useState<UserProfile[]>([]);
   const [loading, setLoading] = useState(true);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [dialogMode, setDialogMode] = useState<DialogMode>("edit");
+  const [selectedUser, setSelectedUser] = useState<UserProfile | null>(null);
+  const [selectedRoles, setSelectedRoles] = useState<NormalizedRole[]>(["player"]);
+  const [formState, setFormState] = useState<ProfileFormState>({
+    first_name: "",
+    last_name: "",
+    email: "",
+    phone: "",
+    mobile: "",
+    member_number: "",
+    street: "",
+    postal_code: "",
+    city: "",
+    birthday: "",
+    status: "pending"
+  });
+  const [isSaving, setIsSaving] = useState(false);
   const { toast } = useToast();
 
   useEffect(() => {
@@ -74,13 +113,51 @@ export const UserAdmin = () => {
     }
   };
 
-  const normalizeRole = (role?: string | null) => {
+  const roleOptions = useMemo(() => ([
+    {
+      value: "player" as NormalizedRole,
+      label: "Mitglied",
+      description: "Basisrolle für alle registrierten Mitglieder",
+      icon: User
+    },
+    {
+      value: "captain" as NormalizedRole,
+      label: "Mannschaftsführer",
+      description: "Verwalten Mannschaften und Spieltermine",
+      icon: Shield
+    },
+    {
+      value: "vorstand" as NormalizedRole,
+      label: "Vorstand",
+      description: "Leitet den Verein und gibt neue Mitglieder frei",
+      icon: UsersRound
+    },
+    {
+      value: "admin" as NormalizedRole,
+      label: "Administrator",
+      description: "Hat Zugriff auf alle Verwaltungsfunktionen",
+      icon: Crown
+    }
+  ]), []);
+
+  const statusOptions = useMemo(() => ([
+    { value: "pending", label: "Ausstehend" },
+    { value: "active", label: "Aktiv" },
+    { value: "inactive", label: "Inaktiv" }
+  ]), []);
+
+  const normalizeRole = (role?: AppRole | null): NormalizedRole => {
     if (!role) return "player";
     if (role === "moderator") return "captain";
-    return role;
+    return role as NormalizedRole;
   };
 
-  const getRoleIcon = (role: string) => {
+  const denormalizeRole = (role: NormalizedRole): AppRole => {
+    if (role === "captain") return "moderator";
+    return role as AppRole;
+  };
+
+  const getRoleIcon = (role: NormalizedRole) => {
     switch (role) {
       case "admin":
         return Crown;
@@ -93,7 +170,7 @@ export const UserAdmin = () => {
     }
   };
 
-  const getRoleBadge = (role: string) => {
+  const getRoleBadge = (role: NormalizedRole) => {
     const colors = {
       admin: "bg-gradient-primary text-primary-foreground",
       vorstand: "bg-gradient-to-r from-amber-500 to-amber-600 text-white",
@@ -104,17 +181,29 @@ export const UserAdmin = () => {
   };
 
   const getStatusBadge = (status: string) => {
-    return status === "active" ? "bg-green-100 text-green-800" : "bg-yellow-100 text-yellow-800";
+    if (status === "active") {
+      return "bg-green-100 text-green-800";
+    }
+    if (status === "inactive") {
+      return "bg-slate-100 text-slate-700";
+    }
+    return "bg-yellow-100 text-yellow-800";
   };
 
-  const getRoleLabel = (role: string) => {
+  const getStatusLabel = (status: string) => {
+    if (status === "active") return "Aktiv";
+    if (status === "inactive") return "Inaktiv";
+    return "Ausstehend";
+  };
+
+  const getRoleLabel = (role: NormalizedRole) => {
     const labels: Record<string, string> = {
       admin: "Admin",
       vorstand: "Vorstand",
       captain: "Mannschaftsführer",
-      player: "Spieler"
+      player: "Mitglied"
     };
-    return labels[role] || "Spieler";
+    return labels[role] || "Mitglied";
   };
 
   const getUserDisplayName = (user: UserProfile) => {
@@ -124,49 +213,178 @@ export const UserAdmin = () => {
     return user.email || 'Unbekannter Benutzer';
   };
 
-  const getUserRole = (user: UserProfile) => {
-    return normalizeRole(user.user_roles[0]?.role);
+  const getUserRoles = (user: UserProfile): NormalizedRole[] => {
+    const normalized = (user.user_roles || []).map(role => normalizeRole(role.role));
+    if (!normalized.includes("player")) {
+      normalized.push("player");
+    }
+    return Array.from(new Set(normalized));
   };
 
-  const handleRoleChange = async (userId: string, newRole: string) => {
-    try {
-      // First, delete existing roles for this user
-      const { error: deleteError } = await supabase
-        .from('user_roles')
-        .delete()
-        .eq('user_id', userId);
-      
-      if (deleteError) throw deleteError;
+  const persistRoles = async (userId: string, roles: NormalizedRole[]) => {
+    const normalizedRoles = roles.length > 0 ? roles : ["player"];
+    const finalRoles = Array.from(new Set([...normalizedRoles, "player"]));
 
-      // Then insert the new role
-      const { error: insertError } = await supabase
-        .from('user_roles')
-        .insert([{ user_id: userId, role: newRole as any }]);
-      
-      if (insertError) throw insertError;
+    const { error: deleteError } = await supabase
+      .from('user_roles')
+      .delete()
+      .eq('user_id', userId);
 
-      toast({
-        title: "Erfolg",
-        description: "Rolle wurde aktualisiert.",
+    if (deleteError) throw deleteError;
+
+    const { error: insertError } = await supabase
+      .from('user_roles')
+      .insert(finalRoles.map(role => ({ user_id: userId, role: denormalizeRole(role) })));
+
+    if (insertError) throw insertError;
+  };
+
+  const pendingUsers = useMemo(
+    () => users.filter(user => (user.status || "pending") === "pending"),
+    [users]
+  );
+
+  const resetDialogState = () => {
+    setSelectedUser(null);
+    setSelectedRoles(["player"]);
+    setFormState({
+      first_name: "",
+      last_name: "",
+      email: "",
+      phone: "",
+      mobile: "",
+      member_number: "",
+      street: "",
+      postal_code: "",
+      city: "",
+      birthday: "",
+      status: "pending"
+    });
+    setIsSaving(false);
+  };
+
+  const prepareDialogForUser = (user: UserProfile | null, mode: DialogMode) => {
+    setDialogMode(mode);
+    if (user) {
+      setSelectedUser(user);
+      setSelectedRoles(getUserRoles(user));
+      setFormState({
+        first_name: user.first_name || "",
+        last_name: user.last_name || "",
+        email: user.email || "",
+        phone: user.phone || "",
+        mobile: user.mobile || "",
+        member_number: user.member_number || "",
+        street: user.street || "",
+        postal_code: user.postal_code || "",
+        city: user.city || "",
+        birthday: user.birthday ? user.birthday.split("T")[0] : "",
+        status: user.status || "pending"
       });
+    } else {
+      resetDialogState();
+    }
+    setIsDialogOpen(true);
+  };
 
-      fetchUsers();
-    } catch (error) {
-      console.error('Error updating role:', error);
+  const handleRoleToggle = (role: NormalizedRole, checked: boolean) => {
+    setSelectedRoles(prev => {
+      if (role === "player") {
+        return prev;
+      }
+      if (checked) {
+        return Array.from(new Set([...prev, role]));
+      }
+      return prev.filter(r => r !== role);
+    });
+  };
+
+  const handleFormChange = (field: keyof ProfileFormState) => (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setFormState(prev => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleStatusChange = (value: string) => {
+    setFormState(prev => ({ ...prev, status: value }));
+  };
+
+  const handleSelectPendingUser = (userId: string) => {
+    const user = users.find(u => u.id === userId) || null;
+    if (user) {
+      prepareDialogForUser(user, "create");
+    }
+  };
+
+  const handleDialogClose = (open: boolean) => {
+    setIsDialogOpen(open);
+    if (!open) {
+      resetDialogState();
+    }
+  };
+
+  const handleProfileSubmit = async () => {
+    if (!selectedUser) {
       toast({
-        title: "Fehler",
-        description: "Rolle konnte nicht aktualisiert werden.",
+        title: "Kein Mitglied ausgewählt",
+        description: "Bitte wählen Sie ein Mitglied aus, das bearbeitet werden soll.",
         variant: "destructive"
       });
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      const { error: updateError } = await supabase
+        .from('profiles')
+        .update({
+          first_name: formState.first_name || null,
+          last_name: formState.last_name || null,
+          email: formState.email || null,
+          phone: formState.phone || null,
+          mobile: formState.mobile || null,
+          member_number: formState.member_number || null,
+          street: formState.street || null,
+          postal_code: formState.postal_code || null,
+          city: formState.city || null,
+          birthday: formState.birthday || null,
+          status: formState.status
+        })
+        .eq('id', selectedUser.id);
+
+      if (updateError) throw updateError;
+
+      await persistRoles(selectedUser.user_id, selectedRoles);
+
+      toast({
+        title: dialogMode === "create" ? "Mitglied freigegeben" : "Profil aktualisiert",
+        description:
+          dialogMode === "create"
+            ? "Das Mitglied wurde erfolgreich freigegeben und aktualisiert."
+            : "Die Profilinformationen wurden gespeichert.",
+      });
+
+      handleDialogClose(false);
+      fetchUsers();
+    } catch (error) {
+      console.error('Error updating profile:', error);
+      toast({
+        title: "Fehler",
+        description: "Das Profil konnte nicht gespeichert werden.",
+        variant: "destructive"
+      });
+    } finally {
+      setIsSaving(false);
     }
   };
 
   const filteredUsers = users.filter(user => {
     const displayName = getUserDisplayName(user);
-    const userRole = getUserRole(user);
+    const userRoles = getUserRoles(user);
     const matchesSearch = displayName.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          (user.email && user.email.toLowerCase().includes(searchTerm.toLowerCase()));
-    const matchesRole = roleFilter === "all" || userRole === roleFilter;
+    const matchesRole = roleFilter === "all" || userRoles.includes(roleFilter);
     return matchesSearch && matchesRole;
   });
 
@@ -192,7 +410,10 @@ export const UserAdmin = () => {
           <h1 className="text-3xl font-bold text-foreground">Benutzerverwaltung</h1>
           <p className="text-muted-foreground">Verwalten Sie Vereinsmitglieder und deren Berechtigungen</p>
         </div>
-        <Button className="bg-gradient-primary hover:bg-primary-hover shadow-sport">
+        <Button
+          className="bg-gradient-primary hover:bg-primary-hover shadow-sport"
+          onClick={() => prepareDialogForUser(pendingUsers[0] ?? null, "create")}
+        >
           <UserPlus className="w-4 h-4 mr-2" />
           Neues Mitglied
         </Button>
@@ -217,7 +438,7 @@ export const UserAdmin = () => {
             <SelectItem value="admin">Administrator</SelectItem>
             <SelectItem value="vorstand">Vorstand</SelectItem>
             <SelectItem value="captain">Mannschaftsführer</SelectItem>
-            <SelectItem value="player">Spieler</SelectItem>
+            <SelectItem value="player">Mitglied</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -231,29 +452,51 @@ export const UserAdmin = () => {
           <div className="space-y-4">
             {filteredUsers.map((user) => {
               const displayName = getUserDisplayName(user);
-              const userRole = getUserRole(user);
-              const RoleIcon = getRoleIcon(userRole);
-              
+              const userRoles = getUserRoles(user);
+              const userStatus = user.status || "pending";
+              const initials = displayName
+                .split(" ")
+                .map((part) => part[0])
+                .join("")
+                .substring(0, 2)
+                .toUpperCase() || "MB";
+
               return (
-                <div key={user.id} className="flex items-center justify-between p-4 rounded-lg border bg-card hover:shadow-accent transition-shadow">
+                <div
+                  key={user.id}
+                  className="flex items-center justify-between p-4 rounded-lg border bg-card hover:shadow-accent transition-shadow cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => prepareDialogForUser(user, "edit")}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      prepareDialogForUser(user, "edit");
+                    }
+                  }}
+                >
                   <div className="flex items-center gap-4">
                     <Avatar>
-                      <AvatarFallback>{displayName.split(' ').map(n => n[0]).join('')}</AvatarFallback>
+                      <AvatarFallback>{initials}</AvatarFallback>
                     </Avatar>
-                    
+
                     <div className="space-y-1">
-                      <div className="flex items-center gap-2">
-                        <h3 className="font-semibold">{displayName}</h3>
-                        <Badge className={getRoleBadge(userRole)}>
-                          <RoleIcon className="w-3 h-3 mr-1" />
-                          {getRoleLabel(userRole)}
-                        </Badge>
-                        <Badge className={getStatusBadge(user.status)} variant="outline">
-                          {user.status === "active" ? "Aktiv" : 
-                           user.status === "pending" ? "Ausstehend" : "Inaktiv"}
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="font-semibold mr-2">{displayName}</h3>
+                        {userRoles.map((role) => {
+                          const RoleIcon = getRoleIcon(role);
+                          return (
+                            <Badge key={`${user.id}-${role}`} className={getRoleBadge(role)}>
+                              <RoleIcon className="w-3 h-3 mr-1" />
+                              {getRoleLabel(role)}
+                            </Badge>
+                          );
+                        })}
+                        <Badge className={getStatusBadge(userStatus)} variant="outline">
+                          {getStatusLabel(userStatus)}
                         </Badge>
                       </div>
-                      <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                      <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
                         {user.email && (
                           <div className="flex items-center gap-1">
                             <Mail className="w-4 h-4" />
@@ -274,40 +517,16 @@ export const UserAdmin = () => {
                   </div>
 
                   <div className="flex items-center gap-2">
-                    <Dialog>
-                      <DialogTrigger asChild>
-                        <Button variant="outline" size="sm">
-                          Rolle ändern
-                        </Button>
-                      </DialogTrigger>
-                      <DialogContent>
-                        <DialogHeader>
-                          <DialogTitle>Rolle zuweisen</DialogTitle>
-                          <DialogDescription>
-                            Rolle für {displayName} ändern
-                          </DialogDescription>
-                        </DialogHeader>
-                        <div className="space-y-4">
-                          <div>
-                            <Label>Neue Rolle</Label>
-                            <Select
-                              defaultValue={userRole}
-                              onValueChange={(value) => handleRoleChange(user.user_id, value)}
-                            >
-                              <SelectTrigger>
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                <SelectItem value="admin">Administrator</SelectItem>
-                                <SelectItem value="vorstand">Vorstand</SelectItem>
-                                <SelectItem value="captain">Mannschaftsführer</SelectItem>
-                                <SelectItem value="player">Spieler</SelectItem>
-                              </SelectContent>
-                            </Select>
-                          </div>
-                        </div>
-                      </DialogContent>
-                    </Dialog>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        prepareDialogForUser(user, "edit");
+                      }}
+                    >
+                      Profil bearbeiten
+                    </Button>
                   </div>
                 </div>
               );
@@ -332,7 +551,7 @@ export const UserAdmin = () => {
             <CardTitle className="text-sm font-medium">Aktive Spieler</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{users.filter(u => u.status === 'active').length}</div>
+            <div className="text-2xl font-bold">{users.filter(u => (u.status || 'pending') === 'active').length}</div>
             <p className="text-xs text-muted-foreground">Verfügbare Mitglieder</p>
           </CardContent>
         </Card>
@@ -342,11 +561,217 @@ export const UserAdmin = () => {
             <CardTitle className="text-sm font-medium">Ausstehende Anfragen</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{users.filter(u => u.status === 'pending').length}</div>
+            <div className="text-2xl font-bold">{users.filter(u => (u.status || 'pending') === 'pending').length}</div>
             <p className="text-xs text-muted-foreground">Benötigen Bestätigung</p>
           </CardContent>
         </Card>
+
+
       </div>
+
+      <Dialog open={isDialogOpen} onOpenChange={handleDialogClose}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>
+              {dialogMode === "create" ? "Neues Mitglied freigeben" : "Mitgliedsprofil bearbeiten"}
+            </DialogTitle>
+            <DialogDescription>
+              {dialogMode === "create"
+                ? "Weisen Sie einem neu registrierten Mitglied die richtigen Rollen zu und schalten Sie es frei."
+                : "Aktualisieren Sie die Profildaten und Rollen des Mitglieds."}
+            </DialogDescription>
+          </DialogHeader>
+
+          {dialogMode === "create" && (
+            <div className="space-y-2">
+              <Label htmlFor="pending-member">Registrierte Mitglieder</Label>
+              {pendingUsers.length > 0 ? (
+                <Select
+                  value={selectedUser?.id ?? pendingUsers[0].id}
+                  onValueChange={handleSelectPendingUser}
+                >
+                  <SelectTrigger id="pending-member">
+                    <SelectValue placeholder="Mitglied auswählen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {pendingUsers.map((user) => (
+                      <SelectItem key={user.id} value={user.id}>
+                        {getUserDisplayName(user)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                  Aktuell warten keine neuen Mitglieder auf ihre Freigabe.
+                </div>
+              )}
+            </div>
+          )}
+
+          {selectedUser && (
+            <div className="space-y-6 pt-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="first_name">Vorname</Label>
+                  <Input
+                    id="first_name"
+                    value={formState.first_name}
+                    onChange={handleFormChange('first_name')}
+                    placeholder="Vorname"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="last_name">Nachname</Label>
+                  <Input
+                    id="last_name"
+                    value={formState.last_name}
+                    onChange={handleFormChange('last_name')}
+                    placeholder="Nachname"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="email">E-Mail</Label>
+                  <Input
+                    id="email"
+                    type="email"
+                    value={formState.email}
+                    onChange={handleFormChange('email')}
+                    placeholder="name@example.com"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="member_number">Mitgliedsnummer</Label>
+                  <Input
+                    id="member_number"
+                    value={formState.member_number}
+                    onChange={handleFormChange('member_number')}
+                    placeholder="z. B. 12345"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="phone">Telefon</Label>
+                  <Input
+                    id="phone"
+                    value={formState.phone}
+                    onChange={handleFormChange('phone')}
+                    placeholder="Festnetz"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="mobile">Mobil</Label>
+                  <Input
+                    id="mobile"
+                    value={formState.mobile}
+                    onChange={handleFormChange('mobile')}
+                    placeholder="Mobilnummer"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="street">Straße</Label>
+                  <Input
+                    id="street"
+                    value={formState.street}
+                    onChange={handleFormChange('street')}
+                    placeholder="Straße und Hausnummer"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="postal_code">PLZ</Label>
+                  <Input
+                    id="postal_code"
+                    value={formState.postal_code}
+                    onChange={handleFormChange('postal_code')}
+                    placeholder="z. B. 12345"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="city">Ort</Label>
+                  <Input
+                    id="city"
+                    value={formState.city}
+                    onChange={handleFormChange('city')}
+                    placeholder="Wohnort"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="birthday">Geburtstag</Label>
+                  <Input
+                    id="birthday"
+                    type="date"
+                    value={formState.birthday}
+                    onChange={handleFormChange('birthday')}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label>Status</Label>
+                  <Select value={formState.status} onValueChange={handleStatusChange}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {statusOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label>Rollen</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Die Basisrolle "Mitglied" bleibt immer aktiv.
+                  </p>
+                  <div className="grid gap-2">
+                    {roleOptions.map((option) => (
+                      <div
+                        key={option.value}
+                        className="flex items-start gap-3 rounded-md border p-3"
+                      >
+                        <Checkbox
+                          id={`role-${option.value}`}
+                          checked={selectedRoles.includes(option.value)}
+                          onCheckedChange={(checked) => handleRoleToggle(option.value, Boolean(checked))}
+                          disabled={option.value === 'player'}
+                        />
+                        <div className="space-y-1">
+                          <Label htmlFor={`role-${option.value}`} className="flex items-center gap-2 text-sm font-medium">
+                            <option.icon className="h-4 w-4" />
+                            {option.label}
+                          </Label>
+                          <p className="text-xs text-muted-foreground">{option.description}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => handleDialogClose(false)}>
+              Abbrechen
+            </Button>
+            <Button
+              className="bg-gradient-primary hover:bg-primary-hover"
+              onClick={handleProfileSubmit}
+              disabled={
+                isSaving ||
+                !selectedUser ||
+                (dialogMode === 'create' && pendingUsers.length === 0)
+              }
+            >
+              {isSaving ? 'Speichern...' : 'Speichern'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/supabase/migrations/20251014120000_update_new_user_status.sql
+++ b/supabase/migrations/20251014120000_update_new_user_status.sql
@@ -1,0 +1,27 @@
+-- Ensure new members require approval by default
+ALTER TABLE public.profiles
+  ALTER COLUMN status SET DEFAULT 'pending';
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.profiles (user_id, first_name, last_name, email, status)
+  VALUES (
+    NEW.id,
+    NEW.raw_user_meta_data ->> 'first_name',
+    NEW.raw_user_meta_data ->> 'last_name',
+    NEW.email,
+    'pending'
+  );
+
+  INSERT INTO public.user_roles (user_id, role)
+  VALUES (NEW.id, 'player')
+  ON CONFLICT (user_id, role) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add dialog-driven profile management in the admin user list with support for multi-role assignments and status approvals
- enrich the user overview with multiple role badges, status filtering, and direct profile editing controls
- ensure newly registered members default to a pending status via a Supabase migration

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb25887d08327a533837e5f03b0b9